### PR TITLE
docs: useAccountBalance in use

### DIFF
--- a/sites/docs/src/pages/docs/hooks/use-account-balance.mdx
+++ b/sites/docs/src/pages/docs/hooks/use-account-balance.mdx
@@ -35,6 +35,6 @@ import { useAccountBalance } from "@crossbell/connect-kit";
 function App() {
 	const balance = useAccountBalance();
 
-	return <div>{balance ? balance.formatted : "No Balance Info"}</div>;
+	return <div>{balance ? balance.balance.formatted : "No Balance Info"}</div>;
 }
 ```

--- a/sites/docs/src/pages/docs/hooks/use-email-account-balance.mdx
+++ b/sites/docs/src/pages/docs/hooks/use-email-account-balance.mdx
@@ -21,6 +21,6 @@ import { useEmailAccountBalance } from "@crossbell/connect-kit";
 function App() {
 	const balance = useEmailAccountBalance();
 
-	return <div>{balance ? balance.formatted : "No Balance Info"}</div>;
+	return <div>{balance ? balance.balance.formatted : "No Balance Info"}</div>;
 }
 ```

--- a/sites/docs/src/pages/docs/hooks/use-wallet-account-balance.mdx
+++ b/sites/docs/src/pages/docs/hooks/use-wallet-account-balance.mdx
@@ -21,6 +21,6 @@ import { useWalletAccountBalance } from "@crossbell/connect-kit";
 function App() {
 	const balance = useWalletAccountBalance();
 
-	return <div>{balance ? balance.formatted : "No Balance Info"}</div>;
+	return <div>{balance ? balance.balance.formatted : "No Balance Info"}</div>;
 }
 ```


### PR DESCRIPTION
use i use useAccountBalance to get the accountBalance i  get i problem, when i use 	const balance = useAccountBalance() to new one balance obj, in  UseAccountBalanceResult have no formatted type, so i have to see the type definition, so i know i should use balance.balance?.formatted to get the formatted, i have try to defined link declare function useAccountBalance(): AccountBalance, 							<div>{balance ? balance?.formatted : "No Balance Info"}</div> but i can‘t get formatted.